### PR TITLE
initialize unproj_dense_points3D as None

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -203,6 +203,7 @@ def run_one_scene(model, images, masks=None, crop_params=None, query_frame_num=3
     batch_num, frame_num, image_dim, height, width = images.shape
     device = images.device
     reshaped_image = images.reshape(batch_num * frame_num, image_dim, height, width)
+    unproj_dense_points3D = None
 
     if cfg.dense_depth:
         print("Predicting dense depth maps via monocular depth estimation.")


### PR DESCRIPTION
Hi,
I found that the recent commit of using depth anything to get dense point clouds results in a simple error of raising the undefined error for the variable unproj_dense_points3D when dense_depth is set to False.
I fixed it by simply adding a None initialization to the code.

Thanks for the great work!
Best regards,
Jaewoo.