### PR TITLE
Improve Hugging Face integration

### DIFF
--- a/vggsfm/models/vggsfm.py
+++ b/vggsfm/models/vggsfm.py
@@ -19,6 +19,8 @@ from huggingface_hub import PyTorchModelHubMixin
 
 class VGGSfM(nn.Module,
              PyTorchModelHubMixin,
+             repo_url="https://github.com/facebookresearch/vggsfm",
+             pipeline_tag="image-to-3D",
              coders={
                 DictConfig : (
                     lambda x: OmegaConf.to_container(x, resolve=True),  # Encoder: how to convert a `DictConfig` to a valid jsonable value?
@@ -33,13 +35,6 @@ class VGGSfM(nn.Module,
         TRACK, CAMERA, TRIANGULAE are the dicts to construct the model modules
         cfg is the whole hydra config
         """
-        print("TRACK", TRACK)
-        print("Type of TRACK", type(TRACK))
-        print("CAMERA", CAMERA)
-        print("Type of CAMERA", type(CAMERA))
-        print("TRIANGULAE", TRIANGULAE)
-        print("CFG", cfg)
-        print("Type of CFG", type(cfg))
         super().__init__()
 
         self.cfg = cfg
@@ -52,19 +47,3 @@ class VGGSfM(nn.Module,
 
         # models.Triangulator
         self.triangulator = instantiate(TRIANGULAE, _recursive_=False, cfg=cfg)
-
-    # def from_pretrained(self, model_name):
-    #     try:
-    #         from huggingface_hub import hf_hub_download
-
-    #         ckpt_path = hf_hub_download(
-    #             repo_id="facebook/VGGSfM", filename=model_name + ".bin"
-    #         )
-    #         checkpoint = torch.load(ckpt_path, map_location="cpu")
-    #     except:
-    #         # In case the model is not hosted on huggingface
-    #         # or the user cannot import huggingface_hub correctly
-    #         _VGGSFM_URL = "https://huggingface.co/facebook/VGGSfM/resolve/main/vggsfm_v2_0_0.bin"
-    #         checkpoint = torch.hub.load_state_dict_from_url(_VGGSFM_URL)
-
-    #     self.load_state_dict(checkpoint, strict=True)

--- a/vggsfm/models/vggsfm.py
+++ b/vggsfm/models/vggsfm.py
@@ -6,14 +6,15 @@
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict
 
 from hydra.utils import instantiate
 
+from huggingface_hub import PyTorchModelHubMixin
 
-class VGGSfM(nn.Module):
+
+class VGGSfM(nn.Module, PyTorchModelHubMixin):
     def __init__(self, TRACK: Dict, CAMERA: Dict, TRIANGULAE: Dict, cfg=None):
         """
         Initializes a VGGSfM model

--- a/vggsfm/models/vggsfm.py
+++ b/vggsfm/models/vggsfm.py
@@ -11,11 +11,22 @@ from typing import Dict
 
 from hydra.utils import instantiate
 
+from omegaconf import OmegaConf
+from omegaconf.dictconfig import DictConfig
+
 from huggingface_hub import PyTorchModelHubMixin
 
 
-class VGGSfM(nn.Module, PyTorchModelHubMixin):
-    def __init__(self, TRACK: Dict, CAMERA: Dict, TRIANGULAE: Dict, cfg=None):
+class VGGSfM(nn.Module,
+             PyTorchModelHubMixin,
+             coders={
+                DictConfig : (
+                    lambda x: OmegaConf.to_container(x, resolve=True),  # Encoder: how to convert a `DictConfig` to a valid jsonable value?
+                    lambda data: OmegaConf.create(data),  # Decoder: how to reconstruct a `DictConfig` from a dictionary?
+                ),
+            }
+    ):
+    def __init__(self, TRACK: DictConfig, CAMERA: DictConfig, TRIANGULAE: DictConfig, cfg: DictConfig = None):
         """
         Initializes a VGGSfM model
 

--- a/vggsfm/models/vggsfm.py
+++ b/vggsfm/models/vggsfm.py
@@ -42,7 +42,7 @@ class VGGSfM(nn.Module, PyTorchModelHubMixin):
             ckpt_path = hf_hub_download(
                 repo_id="facebook/VGGSfM", filename=model_name + ".bin"
             )
-            checkpoint = torch.load(ckpt_path)
+            checkpoint = torch.load(ckpt_path, map_location="cpu")
         except:
             # In case the model is not hosted on huggingface
             # or the user cannot import huggingface_hub correctly

--- a/vggsfm/models/vggsfm.py
+++ b/vggsfm/models/vggsfm.py
@@ -22,6 +22,13 @@ class VGGSfM(nn.Module, PyTorchModelHubMixin):
         TRACK, CAMERA, TRIANGULAE are the dicts to construct the model modules
         cfg is the whole hydra config
         """
+        print("TRACK", TRACK)
+        print("Type of TRACK", type(TRACK))
+        print("CAMERA", CAMERA)
+        print("Type of CAMERA", type(CAMERA))
+        print("TRIANGULAE", TRIANGULAE)
+        print("CFG", cfg)
+        print("Type of CFG", type(cfg))
         super().__init__()
 
         self.cfg = cfg

--- a/vggsfm/models/vggsfm.py
+++ b/vggsfm/models/vggsfm.py
@@ -35,18 +35,18 @@ class VGGSfM(nn.Module, PyTorchModelHubMixin):
         # models.Triangulator
         self.triangulator = instantiate(TRIANGULAE, _recursive_=False, cfg=cfg)
 
-    def from_pretrained(self, model_name):
-        try:
-            from huggingface_hub import hf_hub_download
+    # def from_pretrained(self, model_name):
+    #     try:
+    #         from huggingface_hub import hf_hub_download
 
-            ckpt_path = hf_hub_download(
-                repo_id="facebook/VGGSfM", filename=model_name + ".bin"
-            )
-            checkpoint = torch.load(ckpt_path, map_location="cpu")
-        except:
-            # In case the model is not hosted on huggingface
-            # or the user cannot import huggingface_hub correctly
-            _VGGSFM_URL = "https://huggingface.co/facebook/VGGSfM/resolve/main/vggsfm_v2_0_0.bin"
-            checkpoint = torch.hub.load_state_dict_from_url(_VGGSFM_URL)
+    #         ckpt_path = hf_hub_download(
+    #             repo_id="facebook/VGGSfM", filename=model_name + ".bin"
+    #         )
+    #         checkpoint = torch.load(ckpt_path, map_location="cpu")
+    #     except:
+    #         # In case the model is not hosted on huggingface
+    #         # or the user cannot import huggingface_hub correctly
+    #         _VGGSFM_URL = "https://huggingface.co/facebook/VGGSfM/resolve/main/vggsfm_v2_0_0.bin"
+    #         checkpoint = torch.hub.load_state_dict_from_url(_VGGSFM_URL)
 
-        self.load_state_dict(checkpoint, strict=True)
+    #     self.load_state_dict(checkpoint, strict=True)

--- a/vggsfm/runners/runner.py
+++ b/vggsfm/runners/runner.py
@@ -115,7 +115,9 @@ class VGGSfMRunner:
         # if self.cfg.auto_download_ckpt:
         #     vggsfm.from_pretrained(self.cfg.model_name)
         # else:
-        checkpoint = torch.load(self.cfg.resume_ckpt)
+        from huggingface_hub import hf_hub_download
+        filepath = hf_hub_download(repo_id="facebook/VGGSfM", filename="vggsfm_v2_0_0.bin", repo_type="model")
+        checkpoint = torch.load(filepath, map_location="cpu")
         vggsfm.load_state_dict(checkpoint, strict=True)
         self.vggsfm_model = vggsfm.to(self.device).eval()
         print("VGGSfM built successfully")

--- a/vggsfm/runners/runner.py
+++ b/vggsfm/runners/runner.py
@@ -112,11 +112,11 @@ class VGGSfMRunner:
                 self.cfg.MODEL, _recursive_=False, cfg=self.cfg
             )
 
-        if self.cfg.auto_download_ckpt:
-            vggsfm.from_pretrained(self.cfg.model_name)
-        else:
-            checkpoint = torch.load(self.cfg.resume_ckpt)
-            vggsfm.load_state_dict(checkpoint, strict=True)
+        # if self.cfg.auto_download_ckpt:
+        #     vggsfm.from_pretrained(self.cfg.model_name)
+        # else:
+        checkpoint = torch.load(self.cfg.resume_ckpt)
+        vggsfm.load_state_dict(checkpoint, strict=True)
         self.vggsfm_model = vggsfm.to(self.device).eval()
         print("VGGSfM built successfully")
 


### PR DESCRIPTION
This PR showcases how a VGGSfM model can be safely pushed to the hub using the PyTorchModelHubMixin. It leverages safetensors to safely store the weights.

By inherting from this class, the following automatically works:

```python
from vggsfm.models.vggsfm import VGGSfM

model = VGGSfM.from_pretrained("nielsr/vggsfm")

# push a trained model to the hub
model.push_to_hub("nielsr/my-new-vggsfm-model")

# save locally as safetensors
model.save_pretrained("path_to_local_folder")
```

The model is here for now: https://huggingface.co/nielsr/vggsfm, but we can push it to the `facebook` org instead. As can be seen, download stats also work, along with automated tags ("image-to-3D") and model card:

<img width="1552" alt="Screenshot 2024-08-14 at 23 07 23" src="https://github.com/user-attachments/assets/90c15319-2f62-450c-b633-2e52f84ac3ab">

The entire init arguments are serialized as well into a single config.json: https://huggingface.co/nielsr/vggsfm/blob/main/config.json.