### PR TITLE
Fix off-by-one indexing to fit COLMAP format

### DIFF
--- a/vggsfm/runners/runner.py
+++ b/vggsfm/runners/runner.py
@@ -1022,12 +1022,12 @@ class VGGSfMRunner:
             # Rename the images to the original names
             pyimage = reconstruction.images[pyimageid]
             pycamera = reconstruction.cameras[pyimage.camera_id]
-            pyimage.name = image_paths[pyimageid]
+            pyimage.name = image_paths[pyimageid-1]
 
             if rescale_camera:
                 # Rescale the camera parameters
                 pred_params = copy.deepcopy(pycamera.params)
-                real_image_size = crop_params[0, pyimageid][:2]
+                real_image_size = crop_params[0, pyimageid-1][:2]
                 resize_ratio = real_image_size.max() / img_size
                 real_focal = resize_ratio * pred_params[0]
                 real_pp = real_image_size.cpu().numpy() // 2
@@ -1042,7 +1042,7 @@ class VGGSfMRunner:
 
             if shift_point2d_to_original_res:
                 # Also shift the point2D to original resolution
-                top_left = crop_params[0, pyimageid][-4:-2].abs().cpu().numpy()
+                top_left = crop_params[0, pyimageid-1][-4:-2].abs().cpu().numpy()
                 for point2D in pyimage.points2D:
                     point2D.xy = (point2D.xy - top_left) * resize_ratio
 

--- a/vggsfm/utils/tensor_to_pycolmap.py
+++ b/vggsfm/utils/tensor_to_pycolmap.py
@@ -103,7 +103,7 @@ def batch_matrix_to_pycolmap(
                 width=image_size[0],
                 height=image_size[1],
                 params=pycolmap_intri,
-                camera_id=fidx,
+                camera_id=fidx + 1,
             )
 
             # add camera
@@ -115,8 +115,8 @@ def batch_matrix_to_pycolmap(
             extrinsics[fidx][:3, 3],
         )  # Rot and Trans
         image = pycolmap.Image(
-            id=fidx,
-            name=f"image_{fidx}",
+            id=fidx + 1,
+            name=f"image_{fidx + 1}",
             camera_id=camera.camera_id,
             cam_from_world=cam_from_world,
         )
@@ -142,7 +142,7 @@ def batch_matrix_to_pycolmap(
 
                     # add element
                     track = reconstruction.points3D[point3D_id].track
-                    track.add_element(fidx, point2D_idx)
+                    track.add_element(fidx + 1, point2D_idx)
                     point2D_idx += 1
 
         assert point2D_idx == len(points2D_list)
@@ -189,8 +189,8 @@ def pycolmap_to_batch_matrix(
     extra_params = [] if camera_type == "SIMPLE_RADIAL" else None
 
     for i in range(num_images):
-        # Extract and append extrinsics
-        pyimg = reconstruction.images[i]
+        # Get image with ID i+1 since COLMAP uses 1-based indexing
+        pyimg = reconstruction.images[i + 1]
         pycam = reconstruction.cameras[pyimg.camera_id]
         matrix = pyimg.cam_from_world.matrix()
         extrinsics.append(matrix)


### PR DESCRIPTION
Currently the COLMAP output format is corrupted and crashes eg. OpenMVS's geometric iterations when given as input. This PR fixes the issue. Marked as draft because not thoroughly tested.